### PR TITLE
Implement GC with algorithm option

### DIFF
--- a/.github/workflows/c-test.yml
+++ b/.github/workflows/c-test.yml
@@ -33,17 +33,25 @@ jobs:
       run: make test
     - name: Test with Santizer
       run: make sanitize
+    - name: Test with stress
+      run: make test-stress
     - name: Test optimized
       run: make clean && make -j4 test OPTFLAGS='-O3 -flto=auto'
     - name: Test optimized with Sanitizer
       run: make -j4 sanitize OPTFLAGS='-O3 -flto=auto'
+    - name: Test optimized with stress
+      run: make test-stress OPTFLAGS='-O3 -flto=auto'
     - name: Clang - Make binaries
       run: make clean && make -j4 schaf{,-san} test/basic-test{,-san} CC=clang
     - name: Clang - Test
       run: make test CC=clang
     - name: Clang - Test with Santizer
       run: make sanitize CC=clang
+    - name: Clang - Test with stress
+      run: make test-stress CC=clang
     - name: Clang - Test optimized
       run: make clean && make -j4 test CC=clang OPTFLAGS='-O3 -flto=auto'
     - name: Clang - Test optimized with Sanitizer
       run: make -j4 sanitize CC=clang OPTFLAGS='-O3 -flto=auto'
+    - name: Clang - Test optimized with stress
+      run: make test-stress CC=clang OPTFLAGS='-O3 -flto=auto'

--- a/gc.c
+++ b/gc.c
@@ -81,16 +81,17 @@ static void init_chunk(Header *h, size_t size, Header *next)
     HEADER_NEXT(h) = next;
 }
 
-#define MIN(x, y) ((x) < (y) ? (x) : (y))
 static MSHeapSlot *ms_heap_slot_new(size_t size)
 {
     MSHeapSlot *s = xmalloc(sizeof(MSHeapSlot));
     size = align(size);
     s->size = size;
     s->body = xmalloc(size);
-    Header *h = HEADER(s->body);
-    memset(h, 0, MIN(size, sizeof(SchObject))); // XXX
-    init_chunk(h, size, NULL);
+#if defined(__clang__) // XXX: ???
+#define MIN(x, y) ((x) < (y) ? (x) : (y))
+    memset(s->body, 0, MIN(size, sizeof(Header)));
+#endif
+    init_chunk(HEADER(s->body), size, NULL);
     return s;
 }
 

--- a/gc.c
+++ b/gc.c
@@ -6,12 +6,18 @@
 #include <string.h>
 
 #include "intern.h"
+#include "schaf.h"
 #include "utils.h"
+
+//
+// General definitions
+//
 
 #ifdef DEBUG
 #define xmalloc(size) xcalloc(1, size);
 #endif
 
+// Types
 enum {
     MiB = 1024 * 1024,
     HEAP_RATIO = 2,
@@ -20,75 +26,87 @@ enum {
 
 typedef struct {
     size_t size, used;
+} HeapStat;
+
+typedef struct {
+    void (*init)(const uintptr_t *volatile sp);
+    void (*fin)(void);
+    void *(*malloc)(size_t size);
+    void (*stat)(HeapStat *stat);
+} GCFunctions;
+
+static void heap_print_stat(const char *header);
+static size_t heap_size(void);
+[[gnu::noreturn]] static void error_out_of_memory(void);
+
+// Static data
+static void *gc_data; // singleton; maybe a heap or some context
+static GCFunctions funcs;
+static size_t init_size = 1 * MiB;
+
+static const uintptr_t *volatile stack_base;
+
+static bool stress, print_stat;
+static bool in_gc, initialized;
+
+//
+// Algorithm: Epsilon
+//
+
+typedef struct {
+    size_t size, used;
     uint8_t *body;
-} HeapSlot;
+} EpsHeapSlot;
 
 typedef struct {
     size_t size;
     // 64 is enough large, it can use up the entire 64-bit memory space
     // (= (fold + 0 (map (cut expt 2 <>) (iota 64))) (- (expt 2 64) 1)) ;;=> #t
-    HeapSlot *slot[64];
-} Heap;
-
-typedef struct {
-    size_t size, used;
-} HeapStat;
-
-static size_t init_size = 1 * MiB;
-static Heap heap; // singleton
-
-static const uintptr_t *volatile stack_base;
-
-static bool stress, print_stat;
-static bool in_gc;
-
-void sch_set_gc_init_size(double init_mib)
-{
-    init_size = round(init_mib * MiB);
-}
-
-void sch_set_gc_stress(bool b)
-{
-    stress = b;
-}
-
-void sch_set_gc_print_stat(bool b)
-{
-    print_stat = b;
-}
+    EpsHeapSlot *slot[64];
+} EpsHeap;
 
 static inline size_t align(size_t size)
 {
     return (size + 15U) / 16U * 16U;
 }
 
-static HeapSlot *heap_slot_new(size_t size)
+static EpsHeapSlot *eps_heap_slot_new(size_t size)
 {
-    HeapSlot *h = xmalloc(sizeof(HeapSlot));
+    EpsHeapSlot *h = xmalloc(sizeof(EpsHeapSlot));
     h->size = align(size);
     h->used = 0;
     h->body = xmalloc(size);
     return h;
 }
 
-void gc_fin(void)
-{
-    for (size_t i = 0; i < heap.size; i++) {
-        free(heap.slot[i]->body);
-        free(heap.slot[i]);
-    }
-}
-
-void gc_init(const uintptr_t *volatile sp)
+static void eps_init(const uintptr_t *volatile sp)
 {
     stack_base = sp;
-    heap.slot[0] = heap_slot_new(init_size);
-    heap.size = 1;
+    EpsHeap *heap = xmalloc(sizeof(EpsHeap));
+    heap->slot[0] = eps_heap_slot_new(init_size);
+    heap->size = 1;
+    gc_data = heap;
 }
 
-static void *allocate(size_t size)
+static void eps_fin(void)
 {
-    HeapSlot *last = heap.slot[heap.size-1]; // use the last slot only
+    EpsHeap *heap = gc_data;
+    for (size_t i = 0; i < heap->size; i++) {
+        free(heap->slot[i]->body);
+        free(heap->slot[i]);
+    }
+    free(heap);
+}
+
+static inline EpsHeapSlot *last_slot(EpsHeap *heap)
+{
+    return heap->slot[heap->size - 1];
+}
+
+static void *eps_allocate(size_t size)
+{
+    EpsHeap *heap = gc_data;
+    EpsHeapSlot *last = last_slot(heap); // use the last slot only
     if (last->used + size > last->size)
         return NULL;
     uint8_t *ret = last->body + last->used;
@@ -96,32 +114,78 @@ static void *allocate(size_t size)
     return ret;
 }
 
-size_t gc_stack_get_size(const uintptr_t *volatile sp)
+static bool eps_has_minimum_free_space(void)
 {
-    return (uint8_t *volatile) stack_base - (uint8_t *volatile) sp;
-}
-
-static bool enough_free_space(void)
-{
+    EpsHeap *heap = gc_data;
     static const size_t minreq = sizeof(Continuation); // maybe the largest
-    HeapSlot *last = heap.slot[heap.size-1];
+    EpsHeapSlot *last = last_slot(heap);
     return (last->size - last->used) >= minreq;
 }
 
-static void increase_heaps(void)
+static void eps_increase_heap(void)
 {
-    HeapSlot *last = heap.slot[heap.size-1];
-    heap.slot[heap.size++] = heap_slot_new(last->size * HEAP_RATIO);
+    EpsHeap *heap = gc_data;
+    EpsHeapSlot *last = last_slot(heap);
+    heap->slot[heap->size++] = eps_heap_slot_new(last->size * HEAP_RATIO);
+}
+
+static void eps_stat(HeapStat *stat)
+{
+    EpsHeap *heap = gc_data;
+    stat->size = stat->used = 0;
+    for (size_t i = 0; i < heap->size; i++) {
+        EpsHeapSlot* slot = heap->slot[i];
+        stat->size += slot->size;
+        stat->used += slot->used;
+    }
+}
+
+static void eps_gc(void)
+{
+    if (UNLIKELY(in_gc))
+        bug("nested GC detected");
+    in_gc = true;
+    if (print_stat)
+        heap_print_stat("GC begin");
+    if (!eps_has_minimum_free_space())
+        eps_increase_heap(); // collects nothing ;)
+    if (print_stat)
+        heap_print_stat("GC end");
+    in_gc = false;
+}
+
+static void *eps_malloc(size_t size)
+{
+    if (stress)
+        eps_gc();
+    size = align(size);
+    void *p = eps_allocate(size);
+    if (!stress && p == NULL) {
+        eps_gc();
+        p = eps_allocate(size);
+    }
+    if (UNLIKELY(p == NULL))
+        error_out_of_memory();
+    return p;
+}
+
+static const GCFunctions GC_FUNCS_EPSILON = {
+    eps_init, eps_fin, eps_malloc, eps_stat
+};
+static const GCFunctions GC_FUNCS_DEFAULT = GC_FUNCS_EPSILON;
+
+//
+// General functions
+//
+
+static void error_out_of_memory(void)
+{
+    error("out of memory; heap (~%zu MiB) exhausted", heap_size() / MiB);
 }
 
 static void heap_stat(HeapStat *stat)
 {
-    stat->size = stat->used = 0;
-    for (size_t i = 0; i < heap.size; i++) {
-        HeapSlot* slot = heap.slot[i];
-        stat->size += slot->size;
-        stat->used += slot->used;
-    }
+    funcs.stat(stat);
 }
 
 static void heap_print_stat(const char *header)
@@ -136,21 +200,6 @@ static void heap_print_stat(const char *header)
           n, stat.used, n, stat.size, r/10, r%10);
 }
 
-static void gc(void)
-{
-    if (UNLIKELY(in_gc))
-        bug("nested GC detected");
-    in_gc = true;
-    if (print_stat)
-        heap_print_stat("GC begin");
-    // collects nothing
-    if (!enough_free_space())
-        increase_heaps();
-    if (print_stat)
-        heap_print_stat("GC end");
-    in_gc = false;
-}
-
 static size_t heap_size(void)
 {
     HeapStat stat;
@@ -158,17 +207,55 @@ static size_t heap_size(void)
     return stat.size;
 }
 
+#define error_if_gc_initialized() if (initialized) error("%s called after GC initialization", __func__)
+
+void sch_set_gc_init_size(double init_mib)
+{
+    error_if_gc_initialized();
+    init_size = round(init_mib * MiB);
+}
+
+void sch_set_gc_stress(bool b)
+{
+    stress = b;
+}
+
+void sch_set_gc_print_stat(bool b)
+{
+    print_stat = b;
+}
+
+void sch_set_gc_algorithm(SchGCAlgorithm s)
+{
+    error_if_gc_initialized();
+    switch (s) {
+    case GC_ALGORITHM_EPSILON:
+        funcs = GC_FUNCS_EPSILON;
+        break;
+    default:
+        UNREACHABLE();
+    }
+}
+
+void gc_init(const uintptr_t *volatile sp)
+{
+    if (funcs.init == NULL)
+        funcs = GC_FUNCS_DEFAULT;
+    funcs.init(sp);
+    initialized = true;
+}
+
+void gc_fin(void)
+{
+    funcs.fin();
+}
+
 void *gc_malloc(size_t size)
 {
-    if (stress)
-        gc();
-    size = align(size);
-    void *p = allocate(size);
-    if (!stress && p == NULL) {
-        gc();
-        p = allocate(size);
-    }
-    if (UNLIKELY(p == NULL))
-        error("out of memory; heap (~%zu MiB) exhausted", heap_size() / MiB);
-    return p;
+    return funcs.malloc(size);
+}
+
+size_t gc_stack_get_size(const uintptr_t *volatile sp)
+{
+    return (uint8_t *volatile) stack_base - (uint8_t *volatile) sp;
 }

--- a/intern.h
+++ b/intern.h
@@ -127,8 +127,8 @@ typedef enum {
 
 typedef struct {
     Header header;
-    PortType type;
     FILE *fp;
+    PortType type;
     char *string;
 } Port;
 

--- a/intern.h
+++ b/intern.h
@@ -178,6 +178,7 @@ void source_free(Source *s);
 void gc_init(const uintptr_t *volatile base_sp);
 void gc_fin(void);
 size_t gc_stack_get_size(const uintptr_t *volatile sp);
+void gc_add_root(const Value *r);
 ATTR_XMALLOC void *gc_malloc(size_t size);
 
 bool sch_value_is_integer(Value v);

--- a/intern.h
+++ b/intern.h
@@ -53,6 +53,7 @@ typedef enum {
 typedef struct {
     ValueTag tag;
     bool immutable;
+    bool living; // used in GC
 } Header;
 
 typedef struct {
@@ -249,7 +250,7 @@ static inline Value list2_const(Value x, Value y)
 }
 
 #define DUMMY_PAIR() ((Value) &(SchObject) { \
-            .header = { .tag = TAG_PAIR, .immutable = false }, \
+            .header = { .tag = TAG_PAIR, .immutable = false, .living = false }, \
             .pair = { .car = Qundef, .cdr = Qnil } \
         })
 

--- a/intern.h
+++ b/intern.h
@@ -47,15 +47,12 @@ typedef enum {
     TAG_EOF,
     // internal use only
     TAG_ERROR,
-    TAG_CHUNK,  // not allocated
     TAG_LAST = TAG_ERROR
 } ValueTag;
 
 typedef struct {
     ValueTag tag;
     bool immutable;
-    bool living; // used in GC
-    size_t size;
 } Header;
 
 typedef struct {
@@ -141,8 +138,7 @@ typedef struct {
 typedef struct {
     Header header; // common
     union {
-        alignas(16) Header *next;
-        char *hstring;
+        alignas(16) char *hstring;
         char estring[sizeof(Continuation)];// may be the largest
         Pair pair;
         LocatedPair lpair;
@@ -162,7 +158,6 @@ typedef struct {
 #define HEADER(v) (&OBJ(v)->header)
 #define VALUE_TAG(v) (HEADER(v)->tag)
 
-#define HEADER_NEXT(v) (OBJ(v)->next)
 #define PAIR(v) (&OBJ(v)->pair)
 #define LOCATED_PAIR(v) (&OBJ(v)->lpair)
 #define ESTRING(v) (OBJ(v)->estring)
@@ -253,7 +248,7 @@ static inline Value list2_const(Value x, Value y)
 }
 
 #define DUMMY_PAIR() ((Value) &(SchObject) { \
-            .header = { .tag = TAG_PAIR, .immutable = false, .living = false }, \
+            .header = { .tag = TAG_PAIR, .immutable = false }, \
             .pair = { .car = Qundef, .cdr = Qnil } \
         })
 #define GET_SP(p) uintptr_t v##p = 0, *volatile p = &v##p; UNPOISON(&p, sizeof(uintptr_t *))

--- a/parse.c
+++ b/parse.c
@@ -460,12 +460,13 @@ static Value parse_dotted_pair(Parser *p, Value l, Value last)
 
 static Value located_list1(Value sym, int64_t pos)
 {
-    LocatedPair *p = obj_new(TAG_PAIR, sizeof(LocatedPair)); // imitate ordinal pairs
-    HEADER(p)->immutable = true;
-    PAIR(p)->car = sym;
-    PAIR(p)->cdr = Qnil;
-    p->pos = pos;
-    return (Value) p;
+    SchObject *o = obj_new(TAG_PAIR); // imitate ordinal pairs
+    HEADER(o)->immutable = true;
+    Pair *p = PAIR(o);
+    p->car = sym;
+    p->cdr = Qnil;
+    LOCATED_PAIR(o)->pos = pos;
+    return (Value) o;
 }
 
 static Value parse_list(Parser *p)

--- a/parse.c
+++ b/parse.c
@@ -460,13 +460,12 @@ static Value parse_dotted_pair(Parser *p, Value l, Value last)
 
 static Value located_list1(Value sym, int64_t pos)
 {
-    SchObject *o = obj_new(TAG_PAIR); // imitate ordinal pairs
-    HEADER(o)->immutable = true;
-    Pair *p = PAIR(o);
-    p->car = sym;
-    p->cdr = Qnil;
-    LOCATED_PAIR(o)->pos = pos;
-    return (Value) o;
+    LocatedPair *p = obj_new(TAG_PAIR, sizeof(LocatedPair)); // imitate ordinal pairs
+    HEADER(p)->immutable = true;
+    PAIR(p)->car = sym;
+    PAIR(p)->cdr = Qnil;
+    p->pos = pos;
+    return (Value) p;
 }
 
 static Value parse_list(Parser *p)

--- a/schaf.c
+++ b/schaf.c
@@ -2886,6 +2886,12 @@ void sch_init(const uintptr_t *sp)
 {
     gc_init(sp);
 
+    gc_add_root(&eof_object);
+    gc_add_root(&current_input_port);
+    gc_add_root(&current_output_port);
+    gc_add_root(&inner_winders);
+    gc_add_root(&inner_continuation);
+
     static char basedir[PATH_MAX];
     load_basedir = getcwd(basedir, sizeof(basedir));
     symbol_names = scary_new(sizeof(char *));
@@ -2899,6 +2905,7 @@ void sch_init(const uintptr_t *sp)
     source_data = scary_new(sizeof(Source *));
 
     env_toplevel = env_new("default");
+    gc_add_root(&env_toplevel);
     Value e = env_toplevel;
 
     // 4. Expressions
@@ -2943,6 +2950,7 @@ void sch_init(const uintptr_t *sp)
     // 5.3. Syntax definitions
     //- define-syntax
     env_null = env_dup("null", e);
+    gc_add_root(&env_null);
 
     // 6. Standard procedures
 
@@ -3061,6 +3069,7 @@ void sch_init(const uintptr_t *sp)
     define_procedure(e, "load", proc_load, 1);
 
     env_r5rs = env_dup("r5rs", e);
+    gc_add_root(&env_r5rs);
 
     // Extensions from R7RS
     // (scheme base)
@@ -3079,4 +3088,5 @@ void sch_init(const uintptr_t *sp)
     define_procedure(e, "schaf-environment", proc_schaf_environment, 0);
 
     env_default = env_dup("default", e);
+    gc_add_root(&env_default);
 }

--- a/schaf.c
+++ b/schaf.c
@@ -123,7 +123,6 @@ static inline bool value_is_procedure(Value v)
     case TAG_PORT:
     case TAG_EOF:
         return false;
-    case TAG_CHUNK:
     case TAG_ERROR:
         break; // internal objects
     }
@@ -180,7 +179,6 @@ Type sch_value_type_of(Value v)
     case TAG_EOF:
         return TYPE_EOF;
     case TAG_ERROR:
-    case TAG_CHUNK:
         break; // internal objects
     }
     bug_invalid_tag(VALUE_TAG(v));
@@ -304,7 +302,6 @@ SchObject *obj_new(ValueTag t)
     Header *h = gc_malloc(sizeof(SchObject));
     h->tag = t;
     h->immutable = false;
-    h->living = false;
     return (SchObject *) h;
 }
 

--- a/schaf.c
+++ b/schaf.c
@@ -303,6 +303,7 @@ SchObject *obj_new(ValueTag t)
     Header *h = HEADER(p);
     h->tag = t;
     h->immutable = false;
+    h->living = false;
     return p;
 }
 

--- a/schaf.h
+++ b/schaf.h
@@ -6,6 +6,10 @@
 
 typedef uintptr_t SchValue;
 
+typedef enum {
+    GC_ALGORITHM_EPSILON = 1
+} SchGCAlgorithm;
+
 extern const SchValue SCH_NULL, SCH_UNDEF, SCH_FALSE, SCH_TRUE;
 
 void sch_init(const uintptr_t *volatile base);
@@ -27,5 +31,6 @@ const char *sch_error_message(void);
 void sch_set_gc_init_size(double mib);
 void sch_set_gc_stress(bool b);
 void sch_set_gc_print_stat(bool b);
+void sch_set_gc_algorithm(SchGCAlgorithm s);
 
 #endif

--- a/schaf.h
+++ b/schaf.h
@@ -7,7 +7,8 @@
 typedef uintptr_t SchValue;
 
 typedef enum {
-    GC_ALGORITHM_EPSILON = 1
+    GC_ALGORITHM_MARK_SWEEP = 1,
+    GC_ALGORITHM_EPSILON
 } SchGCAlgorithm;
 
 extern const SchValue SCH_NULL, SCH_UNDEF, SCH_FALSE, SCH_TRUE;


### PR DESCRIPTION
This is another milestone that needs to be recorded:  GC was implemented after about a half-year of effort.

We've implemented a simple and bored Mark-and-sweep GC first, but with a runtime option `--gc=<algo>` to choose the GC algorithm. We now be able to choose 2 algorithms:

* **Mark-and-sweep** <tt>--gc=**mark-sweep**</tt>, the default
* **Epsilon** ;) <tt>--gc=**epsilon**</tt>
  * A.k.a. no GC. It may look like a toy but it's actually useful to check performance of GC itself.
  * Cf. [Epsilon: The JDK’s Do-Nothing Garbage Collector](https://blogs.oracle.com/javamagazine/post/epsilon-the-jdks-do-nothing-garbage-collector)